### PR TITLE
Add TenantId and redirect URI support

### DIFF
--- a/is.yaml
+++ b/is.yaml
@@ -41,6 +41,14 @@ Parameters:
     Type: String
     Description: "IDC application ARN used for create_token_with_iam"
 
+  EnterpriseIdcRedirectUri:
+    Type: String
+    Description: "OIDC redirect URI used for create_token_with_iam"
+
+  TenantId:
+    Type: String
+    Description: "Tenant identifier provided by the ISV"
+
   S3ReactScriptBucket:
     Type: String
     Description: "Bucket that holds install_react.sh"
@@ -330,6 +338,7 @@ Resources:
                 Action:
                   - "sts:AssumeRole"
                   - "sts:SetContext"
+                  - "sts:TagSession"
                 Resource: "*"
               - Effect: "Allow"
                 Action:
@@ -375,6 +384,8 @@ Resources:
           REGION: !Ref AWS::Region
           Q_SERVICE_ROLE_ARN: !Ref QBusinessCrossAccountRoleArn
           IDC_CLIENT_ID: !Ref EnterpriseIdcApplicationArn
+          IDC_REDIRECT_URI: !Ref EnterpriseIdcRedirectUri
+          TENANT_ID: !Ref TenantId
       Code:
         ZipFile: |
           import json
@@ -385,10 +396,9 @@ Resources:
 
           def handler(event, context):
               body = json.loads(event.get("body", "{}"))
-              headers = event.get("headers", {})
-              id_token = headers.get("Authorization", "")
+              code = body.get("code", "")
 
-              if not id_token:
+              if not code:
                   return {
                       "statusCode": 400,
                       "headers": {
@@ -396,24 +406,47 @@ Resources:
                           "Access-Control-Allow-Origin": "*",
                           "Access-Control-Allow-Headers": "Content-Type,Authorization"
                       },
-                      "body": json.dumps({"error": "Missing Authorization header"})
+                      "body": json.dumps({"error": "Missing code"})
                   }
 
               region = os.environ["REGION"]
               q_role_arn = os.environ["Q_SERVICE_ROLE_ARN"]   # cross-account QBusiness role
               idc_client_id = os.environ["IDC_CLIENT_ID"]     # enterprise IDC app
+              redirect_uri = os.environ["IDC_REDIRECT_URI"]
+              tenant_id = os.environ.get("TENANT_ID", "")
 
-              sso_oidc = boto3.client("sso-oidc", region_name=region, config=Config(signature_version='v4'))
-              # Step 1: create_token_with_iam using the Cognito/IDC token
+              sts = boto3.client("sts", region_name=region)
+              pre_assume = sts.assume_role(
+                  RoleArn=q_role_arn,
+                  RoleSessionName="TokenExchangePre",
+                  Tags=[{"Key": "qbusiness-dataaccessor:ExternalId", "Value": tenant_id}]
+              )
+              pre_creds = pre_assume["Credentials"]
+
+              sso_oidc = boto3.client(
+                  "sso-oidc",
+                  region_name=region,
+                  aws_access_key_id=pre_creds["AccessKeyId"],
+                  aws_secret_access_key=pre_creds["SecretAccessKey"],
+                  aws_session_token=pre_creds["SessionToken"],
+                  config=Config(signature_version='v4')
+              )
               idc_resp = sso_oidc.create_token_with_iam(
                   clientId=idc_client_id,
-                  grantType="urn:ietf:params:oauth:grant-type:jwt-bearer",
-                  assertion=id_token
+                  redirectUri=redirect_uri,
+                  grantType="authorization_code",
+                  code=code
               )
               iam_token = idc_resp["idToken"]
 
               # Step 2: assumeRole with ProvidedContexts
-              sts = boto3.client("sts", region_name=region)
+              sts = boto3.client(
+                  "sts",
+                  region_name=region,
+                  aws_access_key_id=pre_creds["AccessKeyId"],
+                  aws_secret_access_key=pre_creds["SecretAccessKey"],
+                  aws_session_token=pre_creds["SessionToken"]
+              )
               parts = iam_token.split(".")
               payload_decoded = json.loads(base64.b64decode(parts[1] + "==="))
 
@@ -425,7 +458,8 @@ Resources:
                           "ProviderArn": "arn:aws:iam::aws:contextProvider/IdentityCenter",
                           "ContextAssertion": payload_decoded["sts:identity_context"],
                       }
-                  ]
+                  ],
+                  Tags=[{"Key": "qbusiness-dataaccessor:ExternalId", "Value": tenant_id}]
               )
               creds = sts_resp["Credentials"]
 

--- a/readme.md
+++ b/readme.md
@@ -1,1 +1,8 @@
-test
+This repository contains a sample CloudFormation template.
+
+Recent updates:
+- Added a new `TenantId` parameter to support tagging STS operations with the
+  tenant identifier.
+- Added `EnterpriseIdcRedirectUri` and updated the TokenExchange Lambda to
+  assume the cross-account role with this tenant tag before calling
+  `create_token_with_iam` using an authorization code.


### PR DESCRIPTION
## Summary
- support new `EnterpriseIdcRedirectUri` parameter in the CloudFormation template
- tag a pre-assumed role before calling `create_token_with_iam` using the authorization code and redirect URI
- propagate the redirect URI to the TokenExchange Lambda
- document new parameter and flow in README

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest` *(command not found)*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.